### PR TITLE
Update Advanced-Features.md

### DIFF
--- a/pages/docs/Advanced-Features.md
+++ b/pages/docs/Advanced-Features.md
@@ -21,13 +21,13 @@ class CustomFeature(configuration: Configuration) {
     // implement ApplicationFeature in a companion object
     companion object Feature : ApplicationFeature<ApplicationCallPipeline, CustomFeature.Configuration, CustomFeature> {
        // create unique key for the feature
-       override val key = AttributeKey<CustomHeader>("CustomFeature")
+       override val key = AttributeKey<CustomFeature>("CustomFeature")
        
        // implement installation script
        override fun install(pipeline: ApplicationCallPipeline, configure: Configuration.() -> Unit): CustomFeature {
            
            // run configuration script
-           val configuration = CustomFeature.Configuration.apply(configure)
+           val configuration = CustomFeature.Configuration().apply(configure)
            
            // create a feature 
            val feature = CustomFeature(configuration)


### PR DESCRIPTION
I had a look at custom features and noticed the following thing:

* The key is still CustomHeader from the example, but this won't compile if it isn't changed to CustomFeature.
* The Configuration has to be initialized first. Otherwise won't compile.