### PR TITLE
fix link to github (now master instead of develop)

### DIFF
--- a/_includes/sample.html
+++ b/_includes/sample.html
@@ -4,7 +4,7 @@
     githubEmbed('#embed', {
         "owner": "ktorio",
         "repo": "ktor",
-        "ref": "develop",
+        "ref": "master",
         "embed": [
     {% for item in split_paths %}
     {% assign file_name = item | split: "/" | last %}


### PR DESCRIPTION
Like mentioned in ktorio/ktor#243, this should fix the link to the correct branch on github.