### PR TITLE
Fixed quickstart Gradle and Maven deadlinks

### DIFF
--- a/pages/quickstart/intellij-idea.md
+++ b/pages/quickstart/intellij-idea.md
@@ -43,8 +43,8 @@ Example
 
 For more detailed guide on setting up build files see
 
-* [Getting Started with Gradle](getting-started-gradle)
-* [Getting Started with Maven](getting-started-maven)
+* [Getting Started with Gradle](gradle)
+* [Getting Started with Maven](maven)
 
 ### Create the App
 


### PR DESCRIPTION
Getting Started with Gradle and Getting Started with Maven deadlinks corrected