### PR TITLE
Fix link to the Artifacts page

### DIFF
--- a/pages/quickstart/application.md
+++ b/pages/quickstart/application.md
@@ -11,7 +11,7 @@ Ktor applications can be built using common build systems such as [Maven](https:
 ### Including the right dependencies
 
 Ktor is split up into several groups of modules, allowing us to include only the functionality that we need. 
-For a list of these modules, please see [Artifacts](artifacts). 
+For a list of these modules, please see [Artifacts](/artifacts).
 In our case we only need to include `ktor-server-netty`.  
 
 These dependencies are hosted on [Bintray](https://bintray.com/kotlin/ktor) and as such the right


### PR DESCRIPTION
Fixed the link from [Quick Start / Application](http://ktor.io/quickstart/application.html) to the [Artifacts](http://ktor.io/artifacts) page.

Removed the redundant trailing space (on the affected line only) along the way.