### PR TITLE
application.conf is ignored when following example

### DIFF
--- a/servers/autoreload.md
+++ b/servers/autoreload.md
@@ -179,8 +179,8 @@ import io.ktor.server.netty.*
 fun main(args: Array<String>) {
     //io.ktor.server.netty.main(args) // Manually using Netty's DevelopmentEngine
     embeddedServer(
-        Netty, watchPaths = listOf("solutions/exercise4"), port = 8080,
-        module = Application::module
+        Netty,
+        commandLineEnvironment(args)
     ).apply { start(wait = true) 
 }
 


### PR DESCRIPTION
Spent an hour trying to figure out why application.conf is ignored
Verified by setting the port to 9000 in `application.conf` but the server still starts on port 8080. 

it seems it only works when we explicitly set `embeddedServer` to read from `commandLineEnvironment`?