### PR TITLE
Fix typo in doc for Route pipeline

### DIFF
--- a/advanced/pipeline/route.md
+++ b/advanced/pipeline/route.md
@@ -24,7 +24,7 @@ fun Route.routeTimeout(time: Long, unit: TimeUnit = TimeUnit.SECONDS, callback: 
     }
     
     // Configure this route with the block provided by the user
-    call(routeWithTimeout)
+    callback(routeWithTimeout)
 
     return routeWithTimeout
 }


### PR DESCRIPTION
Fixes a small typo in the document for calling the user provided route handler