### PR TITLE
Fix ObjectPool example description spelling

### DIFF
--- a/kotlinx/io/tools.md
+++ b/kotlinx/io/tools.md
@@ -8,9 +8,9 @@ toc: false
 ## ObjectPool
 {: #objectpool }
 
-`ObjectPool` is a general purpose lock-free concurrent-safe object pool. It is leak-safe: all object that hasn't been
-recycled but collected by GC do not cause any issues with a pool but only allocation penalty.
-Note that it doens't mean that leaking object will not cause any issues at all as lost objects could
+`ObjectPool` is a general purpose lock-free concurrent-safe object pool. It is leak-safe: all object that haven't been
+recycled but collected by GC do not cause any issues with a pool but only an allocation penalty.
+Note that it doesn't mean that leaking object will not cause any issues at all as lost objects could
 hold some native or external resources. The only guarantee is that `ObjectPool` is not going to break
 if there are lost objects.
 


### PR DESCRIPTION
A few twisted letters and wrong constructs in the description text.