### PR TITLE
Polish English in Advanced section

### DIFF
--- a/advanced/0index.md
+++ b/advanced/0index.md
@@ -7,8 +7,8 @@ priority: -1
 ---
 
 This area of the website is designated for people who are familiar with the basics of developing applications with Ktor.
-Pages in this section will assume an understanding of many things and will not go into explaining them. If you are learning Ktor,
-please be sure to explore other sections ahead of going deeper.  
+Pages in this section assume an understanding of these general concepts and will not go into 
+detail explaining them. If you are learning Ktor, please be sure to explore other sections before going deeper here.  
 
 ### Topics
 

--- a/advanced/authentication.md
+++ b/advanced/authentication.md
@@ -7,30 +7,30 @@ permalink: /advanced/authentication.html
 
 Prerequisite reading: [Advanced Pipeline](/advanced/pipeline.html)
 
-`Authentication` feature creates an `AuthenticationPipeline` which is executed right after `Features` phase
-in call pipeline. All authentication protocols like basic, digest, oauth are implemented as interceptors on AuthenticationPipeline.
+`Authentication` feature creates an `AuthenticationPipeline` which is executed right after the `Features` phase
+in the call pipeline. All authentication protocols such as basic, digest, oauth are implemented as interceptors on `AuthenticationPipeline`.
 
-AuthenticationPipeline has two phases:
+`AuthenticationPipeline` has two phases:
 
-* `CheckAuthentication` – Phase for checking if user is already authenticated before all mechanisms kicks in
-* `RequestAuthentication` – Phase for authentications mechanisms to plug into
+* `CheckAuthentication` – phase for checking if a user is already authenticated before all authentication mechanisms kick in
+* `RequestAuthentication` – phase for authentication mechanisms to plug into
 
 The subject of the pipeline is an `AuthenticationContext` instance.
 
 Protocol:
 
 * Auth provider interceptor tries to find a `Principal` in the context of the current call.
-* If the principal is found, it is returned and the pipeline is finished
-* If the principal is not found, the provider will add a challenge to AuthenticationContext
-* At the end of the pipeline, if there is no principal, we start calling challenges in order
+* If the principal is found, it is returned, and the pipeline is finished.
+* If the principal is not found, the provider will add a challenge to `AuthenticationContext`.
+* At the end of the pipeline, if there is no principal, we start calling challenges in order.
 * Whichever challenge succeeds first wins. 
 
-Example:
+Example Flow:
 
-* Basic auth looks into the `Authorization` header 
-* If it's missing or invalid or the user is not recognized, 401 Unauthorized is sent back to the user and the current call ends
-* Browser shows a dialog, and after credentials are provided it makes a new HTTP request with a proper `Authorization` header
-* Basic auth provider now gets a header, extract credentials and verifies them. 
-* If the credentials are valid, the principal is attached to a call. If not, a 401 is sent back again.
+* Basic auth examines the `Authorization` header. 
+* If it's missing or invalid, or the user is not recognized, a 401 Unauthorized is sent back to the client, and the current call ends.
+* The browser displays a login dialog, and after credentials are provided, it makes a new HTTP request with a proper `Authorization` header.
+* Basic auth provider examines the new header, extracts credentials, and verifies them. 
+* If the credentials are valid, the principal is attached to the call. If not, a 401 is returned to the client again.
 
 

--- a/advanced/build-from-source.md
+++ b/advanced/build-from-source.md
@@ -12,13 +12,13 @@ Ktor is an OpenSource project hosted at GitHub:
 We usually provide binary version previews at bintray:
 <https://bintray.com/kotlin/ktor/ktor>
 
-In addition, you can use jitpack to get bleeding edge artifacts compiled from master:
+Additionally, you can use jitpack to get bleeding edge artifacts compiled from master:
 <https://jitpack.io/#ktorio/ktor>
 
-## Downloading the sources
+## Downloading the source
 {: #get-git-sources}
 
-You can get the lastest version of Ktor using GIT to clone Ktor's repository:
+You can get the latest version of Ktor using git to clone Ktor's repository:
 
 ```
 git clone https://github.com/ktorio/ktor.git
@@ -36,13 +36,13 @@ which should work with any supported system with a JDK installed:
 ./gradlew build
 ```
 
-Right now Ktor doesn't compile with Java 9. So for now, you should stick to Java 8.
+Ktor doesn't yet compile with Java 9, so you should stick with Java 8.
 {: .note }
 
 ## Installing locally
 {: #installing}
 
-Ktor provides a gradle install task, that installs ktor artifacts in your
+Ktor provides a gradle install task that installs Ktor artifacts in your
 local maven repository:
 
 ```
@@ -64,7 +64,7 @@ An exception occurred applying plugin request [id: 'me.champeau.gradle.jmh', ver
    > Could not generate a proxy class for class me.champeau.gradle.JMHPluginExtension.
 ```
 
-You might have forgotten to use the gradle wrapper (`./gradlew`) or your default installed
+You might have forgotten to use the gradle wrapper (`./gradlew`), or your default installed
 gradle version is lower than 4.3.
 
-To ensure that it works, please use the gradle wrapper instead.
+Always use the gradle wrapper for best results!

--- a/advanced/engines.md
+++ b/advanced/engines.md
@@ -7,19 +7,18 @@ keywords: >-
     create custom engine ApplicationEngine
 ---
 
-Ktor's HTTP client and server provide a common interface while allowing
-to use several different engines to perform or to handle HTTP requests.
+Ktor's HTTP client and server provide a common interface while allowing use of several different engines to perform and handle HTTP requests.
 
-Ktor includes several artifacts with several engines:
-* For the server: `Netty`, `Jetty`, `Tomcat`, `CIO`, `TestEngine`.
-* For the client: `ApacheEngine`, `JettyHttp2Engine`, `CIOEngine`, `TestHttpClientEngine`.
+Ktor includes several artifacts and engines:
+* For the server: `Netty`, `Jetty`, `Tomcat`, `CIO`, `TestEngine`
+* For the client: `ApacheEngine`, `JettyHttp2Engine`, `CIOEngine`, `TestHttpClientEngine`
 
 ## Server's `ApplicationEngine`
 {: #server}
 
 ### API
 
-A simplified version of the ApplicationEngine looks like this:
+A simplified version of the `ApplicationEngine` looks like this:
 
 ```kotlin
 interface ApplicationEngineFactory<
@@ -78,16 +77,13 @@ abstract class BaseApplicationEngine(
 
 ### The `ApplicationEngineFactory`
 
-Each implementation of the `ApplicationEngineFactory` along the a subtyped `ApplicationEngine.Configuration`
-are the public exposed APIs for each engine.
+Each implementation of the `ApplicationEngineFactory` along with a subtyped `ApplicationEngine.Configuration` define the publicly exposed APIs for each engine.
 
 ```kotlin
 fun ApplicationEngineFactory.create(environment: ApplicationEngineEnvironment, configure: TConfiguration.() -> Unit): TEngine
 ```
 
-The `ApplicationEngineFactory.create` is in charge of instantiating the right subtyped `ApplicationEngine.Configuration`,
-and call the provided `configure: TConfiguration.() -> Unit` lambda that should mutate the configuration object,
-and constructs an implementation of the `ApplicationEngine` probably subtype of `BaseApplicationEngine`.
+The `ApplicationEngineFactory.create` instantiates the correct subtyped `ApplicationEngine.Configuration` and calls the provided `configure: TConfiguration.() -> Unit` lambda that should mutate the configuration object. It also constructs an implementation of the `ApplicationEngine`, most likely a subtype of `BaseApplicationEngine`.
 
 For example:
 
@@ -111,20 +107,14 @@ class MyApplicationEngineFactory
 
 ### The `ApplicationEngine` and `BaseApplicationEngine`
 
-The interface `ApplicationEngine`, with an abstract implementation `BaseApplicationEngine` is the one in charge
-of starting and stopping the application. It holds the `ApplicationEngineEnvironment` and the constructed
-configuration of the application.
+The interface `ApplicationEngine` with an abstract implementation of `BaseApplicationEngine` starts and stops the application. It holds the `ApplicationEngineEnvironment` as well as the constructed configuration of the application.
 
 This class has two methods:
 
-* The `start` method: it should connect to the `ApplicationEngineEnvironment.connectors` that come from the environment,
-  start the environment, and to start and configure the engine to trigger an execute of the `application` pipeline
-  for each HTTP request with an `ApplicationCall`.
-* The `stop` method: should stop the engine, the environment and to unregister all the things registered by the start method.
+* The `start` method: connects to the `ApplicationEngineEnvironment.connectors` (from the environment), starts the environment, and starts and configures the engine to trigger execution of the `application` pipeline for each HTTP request with an `ApplicationCall`
+* The `stop` method: stops the engine and the environment, and unregisters all items registered by the `start` method
 
-The `BaseApplicationEngine` exposes an `ApplicationEngineEnvironment` passed to the constructor, while
-creates an `EnginePipeline` used as intermediary to pre-intercept the application pipeline. It also installs 
-default transformations the the receive and end pipelines and logs the defined connection endpoints.
+The `BaseApplicationEngine` exposes an `ApplicationEngineEnvironment` passed to the constructor and creates an `EnginePipeline`, which is used as an intermediary to pre-intercept the application pipeline. It also installs default transformations in the send and receive pipelines, and logs the defined connection endpoints.
 
 For example:
 

--- a/advanced/events.md
+++ b/advanced/events.md
@@ -9,17 +9,14 @@ keywords: >-
     subscribing unsubscribing raising raise events dispatching
 ---
 
-At server-side, in addition to handling requests, Ktor exposes a mechanism to produce and consume
+On the server-side, in addition to handling requests, Ktor exposes a mechanism to produce and consume
 global events.
 
-For example, when the application has started, it is starting, or has stopped, an event is produced and you can
-subscribe or unsubscribe to those events to execute code when that happens.
-To do that, associated to the application environment, there is a `monitor: ApplicationEvents` instance
-acting as an event dispatcher.
+For example, when the application is starting, has started, or has stopped, an event is produced. You can subscribe to or unsubscribe from these events and trigger code execution. The `monitor: ApplicationEvents` instance, associated with the application environment, acts as the event dispatcher.
 
-The `ApplicationEvents` dispatches typed `EventDefinition<T>` along an object `T`.
+The `ApplicationEvents` dispatches typed `EventDefinition<T>` along with an object `T`.
 
-You can get the monitor along the application instance by executing `application.environment.monitor`.
+You can get the monitor along with the application instance by executing `application.environment.monitor`.
 
 ### API
 
@@ -55,9 +52,7 @@ val ApplicationStopped: EventDefinition<Application>
 
 ### Subscribing to events and raising them
 
-You can subscribe to events by calling the `subscribe` method from the monitor. The subscribe method returns a
-`DisposableHandle` that you can call to cancel the subscription. Additionally you can call the `unsubscribe`
-method with the same method handle to cancel the subscription.
+You can subscribe to events by calling the `subscribe` method from the monitor. The subscribe method returns a `DisposableHandle` that you can call to cancel the subscription. Additionally, you can call the `unsubscribe` method with the same method handle to cancel the subscription.
 
 Using the disposable:
 
@@ -86,7 +81,7 @@ application.environment.monitor.subscribe(ApplicationStarting, ::starting) // su
 application.environment.monitor.unsubscribe(ApplicationStarting, ::starting) // unsubscribe
 ```
 
-If you want to create custom events and dispatching/raising them:
+If you want to create custom events and dispatch or raise them:
 
 ```kotlin
 class MySubject

--- a/advanced/features.md
+++ b/advanced/features.md
@@ -6,8 +6,7 @@ keywords: plugins
 permalink: /advanced/features.html
 ---
 
-You can develop your own features and reuse them across all your Ktor applications, or you can share them with the community. A typical 
-feature has the following structure:
+You can develop your own features and reuse them across all your Ktor applications, or you can share them with the community. A typical feature has the following structure:
 
 ```kotlin
 class CustomFeature(configuration: Configuration) {
@@ -41,12 +40,11 @@ class CustomFeature(configuration: Configuration) {
 }
 ```
 
-`CustomFeature` is a feature instance class, which should be immutable to avoid unintended side-effects in a highly
-concurrent environment. Feature implementation should be thread-safe as it will be called from multiple threads.
+`CustomFeature` is a feature instance class, which should be immutable to avoid unintended side-effects in a highly concurrent environment. Feature implementation should be thread-safe as it will be called from multiple threads.
 
-The `Configuration` instance is handed to the user installation script and allows the feature configuration. 
+The `Configuration` instance is handed to the user installation script, allowing feature configuration. 
 
-The `Feature` companion object conforms to Ktor API and connects things together.
+The `Feature` companion object conforms to the Ktor API and ties things together.
  
 A feature can be installed with the standard `install` function:
 
@@ -58,4 +56,4 @@ fun Application.main() {
 }
 ```
 
-See a complete example in the [custom feature sample](https://github.com/ktorio/ktor-samples/blob/master/feature/custom-feature/src/CustomHeader.kt)
+See a complete example in the [custom feature sample](https://github.com/ktorio/ktor-samples/blob/master/feature/custom-feature/src/CustomHeader.kt).

--- a/advanced/http2.md
+++ b/advanced/http2.md
@@ -7,8 +7,7 @@ permalink: /advanced/http2.html
 
 [HTTP/2](https://en.wikipedia.org/wiki/HTTP/2) is a modern binary duplex multiplexing protocol designed as a replacement for HTTP/1.x.
 
-Jetty, Netty, and Tomcat engines provide HTTP/2 implementations which Ktor can use. However, there are significant differences, 
-and every engine requires additional configuration. Once your host is configured properly for Ktor, HTTP/2 support will be activated automatically.
+Jetty, Netty, and Tomcat engines provide HTTP/2 implementations that Ktor can use. However, there are significant differences, and each engine requires additional configuration. Once your host is configured properly for Ktor, HTTP/2 support will be activated automatically.
 
 Key requirements:
 
@@ -18,16 +17,14 @@ Key requirements:
 
 ## SSL certificate
 
-As per specification, HTTP/2 does not require encryption, but all browsers will require encrypted connections to be used with HTTP/2. 
-That's why a working TLS is a prerequisite for enabling HTTP/2.
-A certificate is required to enable encryption. For testing purposes, it can be generated with `keytool` from JDK.
+As per the specification, HTTP/2 does not require encryption, but all browsers will require encrypted connections to be used with HTTP/2. That's why a working TLS environment is a prerequisite for enabling HTTP/2. Therefore, a certificate is required to enable encryption. For testing purposes, it can be generated with `keytool` from the JDK:
 
 
 ```bash
 keytool -keystore test.jks -genkeypair -alias testkey -keyalg RSA -keysize 4096 -validity 5000 -dname 'CN=localhost, OU=ktor, O=ktor, L=Unspecified, ST=Unspecified, C=US'
 ```
 
-The next step is configuring ktor to use your keystore. See the example application.conf
+The next step is configuring Ktor to use your keystore. See the example application.conf:
 
 ```
 ktor {
@@ -55,18 +52,15 @@ ktor {
 
 ## ALPN implementation
 
-HTTP/2 requires ALPN ([Application-Layer Protocol Negotiation](https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation) ) 
-to be enabled. Unfortunately, JDK's TLS implementation doesn't have support for ALPN so your application engine needs to be configured properly. 
+HTTP/2 requires ALPN ([Application-Layer Protocol Negotiation](https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation)) to be enabled. Unfortunately, the JDK's TLS implementation doesn't have support for ALPN, so your application engine must be configured properly. 
 The first option is to use an external ALPN implementation that needs to be added to the boot classpath.
-Another option is to use OpenSSL native bindings and precompiled native binaries. Both approaches are error-prone 
-and require extra attention when being configured. Also, each particular engine can support only one of these methods.
+Another option is to use OpenSSL native bindings and precompiled native binaries. Both approaches are error-prone and require extra attention when being configured. Also, each particular engine can support only one of these methods.
 
 ### Jetty
 
-Jetty supports ALPN extension for JDK so to get it working you have to add an extra-dependency to java *boot classpath*. 
-It is very important to add it to the *boot* classpath, as adding it to a regular classpath doesn't work.
-The other issue is that the exact dependency version depends on JDK version. For example, for JDK 8u144 alpn boot 8.1.11.v20170118 
-should be used (see https://www.eclipse.org/jetty/documentation/9.4.x/alpn-chapter.html#alpn-versions for the full compatibility list).
+Jetty supports the JDK ALPN extension, and to get it working you have to add an extra-dependency to the java *boot classpath*. It is very important to add it to the *boot* classpath, as adding it to a regular classpath doesn't work.
+
+The other issue is that the exact dependency version depends on the JDK version. For example, for JDK 8u144, alpn boot 8.1.11.v20170118 should be used (see https://www.eclipse.org/jetty/documentation/9.4.x/alpn-chapter.html#alpn-versions for the full compatibility list).
 
 The following JVM options should be applied (the path can be relative):
 
@@ -74,7 +68,7 @@ The following JVM options should be applied (the path can be relative):
 -Xbootclasspath/p:/path/to/alpn-boot-8.1.11.v20170118.jar
 ```
 
-Depending on your build system you will probably need to copy dependency to some specific directory. 
+Depending on your build system you will probably need to copy the dependency to some specific directory. 
 In Maven you could use `maven-dependency-plugin` (goal `copy-dependencies`) or `Copy` task in Gradle.
 
 ```xml
@@ -101,7 +95,7 @@ In Maven you could use `maven-dependency-plugin` (goal `copy-dependencies`) or `
 ```
 {: .compact}
 
-If all of the above is done properly Jetty will log that ssl, alpn, and h2 are enabled:
+If all of the above is done properly, Jetty will log that ssl, alpn, and h2 are enabled:
 
 ```
 INFO  org.eclipse.jetty.server.Server - jetty-9.4.6.v20170531
@@ -125,7 +119,7 @@ Add an API jar to dependencies:
 </dependency>
 ```
 
-and then  native implementation (statically linked BoringSSL library, a fork of OpenSSL)
+and then  native implementation (statically linked BoringSSL library, a fork of OpenSSL):
 
 ```xml
     <dependency>
@@ -145,17 +139,14 @@ and then  native implementation (statically linked BoringSSL library, a fork of 
 
 where `tc.native.classifier` should be one of the following: `linux-x86_64`, `osx-x86_64` or `windows-x86_64`.
 
-Once all dependencies provided Ktor will enable HTTP/2 support on SSL port.
+Once all dependencies have been provided, Ktor will enable HTTP/2 support on the SSL port.
 
 ### Tomcat and other servlet containers
 
-Similar to Netty, to get HTTP/2 working in Tomcat you need native openssl bindings. Unfortunately original 
-Tomcat's tcnative is not very compatible with Netty's one.
-This is why you need slightly different binaries (you can get it here http://tomcat.apache.org/native-doc/ or you can 
-try Netty's tcnative however you'll have to guess which exact version is compatible with your specific Tomcat version)
+Similar to Netty, to get HTTP/2 working in Tomcat you need native OpenSSL bindings. Unfortunately, Tomcat's tcnative is not completely compatible with the Netty one.
+This is why you need a slightly different binary. You can get it here (http://tomcat.apache.org/native-doc/), or you can try Netty's tcnative. However, you'll have to guess which exact version is compatible with your specific Tomcat version.
 
-If you are deploying your ktor application as a war package into the server (servlet container) then you have to 
-configure your Tomcat server properly:
+If you are deploying your Ktor application as a war package into the server (servlet container), then you will have to configure your Tomcat server properly:
 
 * <https://tomcat.apache.org/tomcat-8.5-doc/config/http.html#HTTP/2_Support>
 * <https://tomcat.apache.org/tomcat-8.5-doc/config/http2.html>

--- a/advanced/pipeline/attributes.md
+++ b/advanced/pipeline/attributes.md
@@ -5,19 +5,19 @@ caption: Passing information among interceptors
 keywords: attributes Passing information among interceptors dependency injector instance container
 ---
 
-Ktor offers an `Attributes` class that acts as a small typed instance container / dependency injector.
+Ktor offers an `Attributes` class that acts as a small typed instance container/dependency injector.
 
 For the server, the `ApplicationCall` contains an `attributes` property including an instance of this class (`call.attributes`).
-The lifespan of this container is the call: since the request has started, until the response is completely sent.
+The lifespan of this container is the call: beginning when the request has started and ending when the response has been sent.
 
-You can put as many attributes as required per call from an interceptor, and retrieve them later in another interceptor.
+You can set as many attributes as required per call on an interceptor and retrieve them later in another interceptor.
 
 In the case of the client, the `HttpRequest` also contains an `attributes` property.
 So from a `HttpClientCall` instance, you can access the attributes with `call.request.attributes`.
 
 ### Basic usage
 
-It is possible to define your own typed attributes, by creating instances of the `AttributeKey` class like this:
+It is possible to define your own typed attributes by creating instances of the `AttributeKey` class like this:
 
 ```kotlin
 // Declared as a global property
@@ -38,7 +38,7 @@ attributes.get(MyAttributeKey)
 
 ### API reference
 
-The full interface for this class, looks like:
+The full interface for this class looks like:
 
 ```kotlin
 interface Attributes {

--- a/advanced/pipeline/route.md
+++ b/advanced/pipeline/route.md
@@ -4,7 +4,7 @@ category: advanced
 caption: Interception per route
 ---
 
-If you want to just intercept some calls for a specific route, you have to create a Route node and intercept that node.
+If you just want to intercept some calls for a specific route, you have to create a `Route` node and intercept that node.
 
 For example, for creating a timeout for a route, you could do the following:
 
@@ -30,9 +30,9 @@ fun Route.routeTimeout(time: Long, unit: TimeUnit = TimeUnit.SECONDS, callback: 
 }
 ```
 
-### Intercepting any Route node
+### Intercepting any `Route` node
 
-Route class defines an intercept method, that applies to that route node or any other inner route:
+The `Route` class defines an intercept method that applies to that route node or any other inner route:
 
 ```kotlin
 /// Installs an interceptor into this route which will be called when this or a child route is selected for a call
@@ -42,13 +42,12 @@ fun Route.intercept(phase: PipelinePhase, block: PipelineInterceptor<Unit, Appli
 ### Getting the route being handled
 {: #route-from-call }
 
-You can get the route being handled by casting the `call: ApplicationCall` to `RoutingApplicationCall` that 
-has a `route: Route` property.
+You can get the route being handled by casting the `call: ApplicationCall` to `RoutingApplicationCall` that has a `route: Route` property.
 
 ### Getting the route path
 {: #route-path }
 
-`Route` overrides the `toString()` to generate a path to the route of the toString, looking something like:
+`Route` overrides the `toString()` method to generate a path to the route, something like:
 
 ```kotlin
 override fun Route.toString() = when {

--- a/advanced/utilities.md
+++ b/advanced/utilities.md
@@ -12,13 +12,12 @@ keywords: >-
 
 Ktor exposes a few extension methods for parsing and generating url-encoded strings (`application/x-www-form-urlencoded`).
 
-URL-encoded strings looks like this: `param=value&other=hi`.
+URL-encoded strings look like: `param=value&other=hi`.
 
 ### Parsing:
 {: #url-encoded-parse}
 
-There is an extension method for `String` that allows to get a parsed `Parameters` object from it. You can limit
-the maximum number of parsed parameters with the optional `limit` parameter.
+There is an extension method for `String` that allows you to get a parsed `Parameters` object from it. You can limit the maximum number of parsed parameters with the optional `limit` parameter.
 
 ```kotlin
 fun String.parseUrlEncodedParameters(defaultEncoding: Charset = Charsets.UTF_8, limit: Int = 1000): Parameters
@@ -27,7 +26,7 @@ fun String.parseUrlEncodedParameters(defaultEncoding: Charset = Charsets.UTF_8, 
 ### Encoding:
 {: #url-encoded-encode}
 
-Either from a List of Pairs of strings or a `Parameters` instance, you can generate an url-encoded string.
+You can generate a URL-encoded string either from a List of Pairs of Strings or a `Parameters` instance: 
 
 ```kotlin
 fun List<Pair<String, String?>>.formUrlEncode(): String
@@ -36,7 +35,7 @@ fun Parameters.formUrlEncode(): String
 fun Parameters.formUrlEncodeTo(out: Appendable)
 ```
 
-You can construct a URL-encoded string, from `List<Pair<String, String>>` like this:
+You can construct a URL-encoded string from `List<Pair<String, String>>` like this:
 
 ```kotlin
 listOf(
@@ -45,8 +44,7 @@ listOf(
 ).formUrlEncode()
 ```
 
-You can also construct it from a `Parameters` instance, that you can instantiate by using the `Parameters.build` builder, and then calling the `formUrlEncode` extension,
-or with the `parametersOf()` builder method:
+You can also construct it from a `Parameters` instance that you can instantiate by using the `Parameters.build` builder and then calling the `formUrlEncode` extension, or with the `parametersOf()` builder method:
 
 ```kotlin
 Parameters.build {
@@ -55,7 +53,7 @@ Parameters.build {
 }.formUrlEncode()
 ```
 
-The `parametersOf` builder has several signatures and there is `Parameters` operator overloading for `+` to join two `Parameters` instances:
+The `parametersOf` builder has several signatures, and there is `Parameters` operator overloading (`+`) to join two `Parameters` instances:
 
 ```kotlin
 parametersOf("a" to "b1", "a" to "b2").formUrlEncode()
@@ -63,7 +61,7 @@ parametersOf("a" to "b1", "a" to "b2").formUrlEncode()
 parametersOf("a", listOf("b1", "b2")).formUrlEncode()
 ```
 
-From a normal `Map<String, String>`, you can also construct a URL encoded string, but you will have first to make a list from it:
+From a normal `Map<String, String>` you can also construct a URL-encoded string, but first you will have to create a List from it:
 
 ```kotlin
 mapOf(
@@ -72,8 +70,7 @@ mapOf(
 ).toList().formUrlEncode()
 ```
 
-URL encoded strings allow to have repeated keys, if you use a `Map<String, String>` as base, you won't be able to
-represent repeated keys.
+URL-encoded strings allow you to have repeated keys. If you use a `Map<String, String>` as base, you won't be able to represent repeated keys.
 {: .note}
 
 You can also construct it from a `Map<String, List<String>>` by *flatMapping* it first:
@@ -85,8 +82,7 @@ mapOf(
 ).flatMap { map -> map.value.map { map.key to it } }.formUrlEncode()
 ```
 
-In the case you want to avoid constructing a whole String with the content,
-and want to write to somewhere directly, you can use the `formUrlEncodeTo` methods instead.
+In case you want to avoid constructing a whole String with the content and instead want to write to somewhere directly, you can use the `formUrlEncodeTo` method.
 
 #### Responding URL-encoded
 


### PR DESCRIPTION
This PR fixes grammar, word choice, punctuation, spelling errors, etc. in the "Advanced" section. I'm a native English speaker (US) and have a Bachelor of Arts in English. I didn't change any code in multiple lines enclosed by triple backticks. If anything wasn't clear to me, I researched it in the Ktor source code.

I'd planned to submit a single PR for all six sections (Quick Start, Servers, Clients, Kotlinx, Samples, Advanced), but since I have some questions, I decided to stop at Advanced and ask them. Once they are answered, I can make necessary changes to this PR and submit a new one for the other five sections.

If you like, I can submit a separate PR for each section. It might be easier for you to review.

Should I continue to use the rules outlined below? The Advanced section was inconsistent, so I want to be sure before continuing.

Backtick usage: I marked up all uses of Ktor artifacts with backticks, including class, method, and property names.

Capitalization of non-Ktor artifacts: I capitalized all class names (List, Pair, String, etc.) without markup when it was not necessary for understanding a code sequence. Here is an example: "You can generate a URL-encoded string either from a List of Pairs of Strings"

Front slashes and spaces: I removed spaces before and after front slashes, for example, "container / dependency" to "container/dependency". Again, I noticed inconsistencies throughout the site, and no spaces is considered standard English usage.
