### PR TITLE
 Add client closing to sample code and requests description

### DIFF
--- a/clients/3http-client.md
+++ b/clients/3http-client.md
@@ -44,6 +44,8 @@ suspend fun sequentialRequests() {
     
     // Once the previous request is done, get the content of an URL.
     val bytes2 = client.call("https://127.0.0.1:8080/b").response.readBytes() // Suspension point.
+    
+    client.close()
 }
 ```
 
@@ -61,6 +63,8 @@ suspend fun parallelRequests() {
     // requests are done.
     val bytes1 = req1.await() // Suspension point.
     val bytes2 = req2.await() // Suspension point.
+    
+    client.close()
 }
 ```
 

--- a/clients/http-client/calls/requests.md
+++ b/clients/http-client/calls/requests.md
@@ -44,6 +44,20 @@ extension method like `HttpClient.get` to do a `GET` request to receive
 the specified type directly (for example `String`).
 {: .note}
 
+After you finish working with the client, it should be closed in order to properly stop the underlying engine.
+
+```kotlin
+client.close()
+```
+
+If you want to use a client to make only one request consider `use`-ing it. The client will be automatically closed once the passed block has been executed.
+
+```kotlin
+val bytes = HttpClient(Apache).use { client ->
+    client.call("http://127.0.0.1:8080/").response.readBytes()
+}
+```
+
 ## Custom requests
 
 We cannot live only on *get* requests, Ktor allows you to build complex


### PR DESCRIPTION
`HttpClient`s should be closed once they have done their work, as demonstrated in the example [here](https://ktor.io/clients/http-client/examples.html#example-json). Otherwise a (ktor) server cannot gracefully stop without polluting logs with exceptions.

I added calls to the `client.close()` method to some samples and also wrote a small paragraph about it on the Requests page.