### PR TITLE
Remove enabling coroutines since the web-site has moved to Kotlin 1.3x

### DIFF
--- a/quickstart/1index.md
+++ b/quickstart/1index.md
@@ -124,8 +124,6 @@ sourceCompatibility = 1.8
 compileKotlin { kotlinOptions.jvmTarget = "1.8" }
 compileTestKotlin { kotlinOptions.jvmTarget = "1.8" }
 
-kotlin { experimental { coroutines "enable" } }
-
 repositories {
     mavenCentral()
     jcenter()

--- a/quickstart/quickstart/gradle.md
+++ b/quickstart/quickstart/gradle.md
@@ -97,9 +97,12 @@ versions, you have to use double-quoted strings.
 
 As for Kotlin 1.2x, coroutines are still an experimental feature, 
 so you will need to tell the compiler that it is okay
-to use them to avoid warnings:
+to use them to avoid warnings. 
+If you are using Kotlin 1.3x or higher, the coroutines are 
+already stable and you can skip this step.
 
 ```groovy
+// Not needed for Kotlin 1.3x or higher
 kotlin {
     experimental {
         coroutines "enable"
@@ -170,12 +173,6 @@ compileKotlin {
 }
 compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
-}
-
-kotlin {
-    experimental {
-        coroutines "enable"
-    }
 }
 
 repositories {

--- a/quickstart/quickstart/maven.md
+++ b/quickstart/quickstart/maven.md
@@ -146,7 +146,9 @@ Now you have to add `ktor-server-core` artifact using the `ktor.version` you spe
 
 As for Kotlin 1.2x, coroutines are still an experimental feature
 in Kotlin, so you will need to tell the compiler that it is okay
-to use them to avoid warnings:
+to use them to avoid warnings.
+If you are using Kotlin 1.3x or higher, the coroutines are 
+already stable and you can skip this flag.
 
 ```xml
 <plugin>
@@ -157,6 +159,7 @@ to use them to avoid warnings:
     <configuration>
         <jvmTarget>1.8</jvmTarget>
         <args>
+            <!-- Not needed for Kotlin 1.3x or higher -->
             <arg>-Xcoroutines=enable</arg>
         </args>
     </configuration>


### PR DESCRIPTION
Coroutine-enabling was removed from gradle templates, but was kept in a general block with a disclaimer for people who can come still using Kotlin 1.2x.