### PR TITLE
Fixed `userNameRealmPasswordDigestProvider`

### DIFF
--- a/servers/features/authentication/digest.md
+++ b/servers/features/authentication/digest.md
@@ -13,13 +13,17 @@ It works differently than the basic/form auths:
 ```kotlin
 authentication {
     digest {
-        val p = "Circle Of Life"
+        val password = "Circle Of Life"
         digester = MessageDigest.getInstance("MD5")
         realm = "testrealm@host.com"
         userNameRealmPasswordDigestProvider = { userName, realm ->
             when (userName) {
                 "missing" -> null
-                else -> digest(digester, "$userName:$realm:$p")
+                else -> {
+                    digester.reset()
+                    digester.update("$userName:$realm:$password".toByteArray())
+                    digester.digest()
+                }
             }
         }
     }


### PR DESCRIPTION
When I've copy-pasted sample code, there was no suitable `digest` method.
So I've copied almost original `userNameRealmPasswordDigestProvider` implementation, but removed ISO charset so password can contain, for instance, cyrillic characters.