### PR TITLE
Meaningful name for auth

### DIFF
--- a/servers/features/authentication/oauth.md
+++ b/servers/features/authentication/oauth.md
@@ -36,7 +36,7 @@ val loginProviders = listOf(
 )
 
 install(Authentication) {
-    oauth("oauth1") {
+    oauth("gitHubOAuth") {
         client = HttpClient(Apache)
         providerLookup = { loginProviders[it.type] }
         urlProvider = { url(login(it.name)) }
@@ -44,7 +44,7 @@ install(Authentication) {
 }
 
 routing {
-    authenticate("oauth1") {
+    authenticate("gitHubOAuth") {
         location<login>() {
             param("error") {
                 handle {


### PR DESCRIPTION
Name `oauth1` is easy to confuse with OAuth 1.0, especially when passed as positional (not named) argument.