### PR TITLE
Fixed providerLookup (by copy-pasting from sample)

### DIFF
--- a/servers/features/authentication/oauth.md
+++ b/servers/features/authentication/oauth.md
@@ -38,7 +38,7 @@ val loginProviders = listOf(
 install(Authentication) {
     oauth("oauth1") {
         client = HttpClient(Apache)
-        providerLookup = { loginProviders[it.type] }
+        providerLookup = { loginProviders[application.locations.resolve<login>(login::class, this).type] }
         urlProvider = { url(login(it.name)) }
     }
 }


### PR DESCRIPTION
`providerLookup` has type of `ApplicationCall.() -> OAuthServerSettings?` and, when implemented by lambda, has no inferred `it` parameter, so the original code won't compile.