### PR TITLE
Fix borken links in 9features.md

### DIFF
--- a/clients/http-client/9features.md
+++ b/clients/http-client/9features.md
@@ -13,9 +13,9 @@ there is a pipeline for client HTTP requests, and there are interceptors and ins
 
 ## Creating Custom Features
 
-If you want to create features, you can use the [standard features](https://github.com/ktorio/ktor/tree/master/ktor-client/ktor-client-core/src/io/ktor/client/features) as a reference.
+If you want to create features, you can use the [standard features](https://github.com/ktorio/ktor/tree/master/ktor-client/ktor-client-core/common/src/io/ktor/client/features) as a reference.
 
-You can also check the [HttpRequestPipeline.Phases](https://github.com/ktorio/ktor/blob/master/ktor-client/ktor-client-core/src/io/ktor/client/request/HttpRequestPipeline.kt)
-and [HttpResponsePipeline.Phases](https://github.com/ktorio/ktor/blob/master/ktor-client/ktor-client-core/src/io/ktor/client/response/HttpResponsePipeline.kt)
+You can also check the [HttpRequestPipeline.Phases](https://github.com/ktorio/ktor/blob/master/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequestPipeline.kt)
+and [HttpResponsePipeline.Phases](https://github.com/ktorio/ktor/blob/master/ktor-client/ktor-client-core/common/src/io/ktor/client/response/HttpResponsePipeline.kt)
 to understand the interception points available.
 {: .note.tip}


### PR DESCRIPTION
Links pointing to custom features in client documentation needs to be updated. Thanks