### PR TITLE
Clarify terms Accept header priority

### DIFF
--- a/servers/features/routing.md
+++ b/servers/features/routing.md
@@ -138,7 +138,7 @@ accept(ContentType.Text.Html) { … }
 The routing matching algorithm not only checks if a particular HTTP request matches a specific path in a routing tree, but
 it also calculates the quality of the match and selects the routing node with the best quality.  Given the routes above,
 which match on the Accept header, and given the request header `Accept: text/plain; q=0.5, text/html` will match
-`text/html` because the quality factor in the HTTP header indicates a higher priority for`text/plain` (default is 1.0).
+`text/html` because the quality factor in the HTTP header indicates a lower quality for`text/plain` (default is 1.0).
 
 The Header `Accept: text/plain, text/*` will match `text/plain`. Wildcard matches are considered less specific than direct matches. Therefore the routing matching algorithm will consider them to have a lower quality.
 


### PR DESCRIPTION
Since the documentation does not describe if `higher priority == higher quality` or `lower priority == higher quality`, be consistent and just use "lower quality".