### PR TITLE
Fix some typos in quickstart documentation

### DIFF
--- a/quickstart/guides/1website.md
+++ b/quickstart/guides/1website.md
@@ -89,7 +89,7 @@ fun Application.module() {
     }
     
     routing {
-        get("/") {
+        get("/html-freemarker") {
             call.respond(FreeMarkerContent("index.ftl", mapOf("data" to IndexData(listOf(1, 2, 3))), ""))
         }
     }
@@ -137,9 +137,9 @@ In addition to this, we will have to update our template to include the `style.c
     <head>
         <link rel="stylesheet" href="/static/styles.css">
     </head>
-	<body>
-	    <!-- ... -->
-	</body>
+    <body>
+	<!-- ... -->
+    </body>
 </html>
 ```
 
@@ -272,11 +272,13 @@ fun Application.module() {
     install(Sessions) {
         cookie<MySession>("SESSION")
     }
-    authenticate("login") {
-        post {
-            val principal = call.principal<UserIdPrincipal>() ?: error("No principal")
-            call.sessions.set(MySession(principal.name))
-            call.respondRedirect("/", permanent = false)
+    routing {
+        authenticate("login") {
+            post {
+                val principal = call.principal<UserIdPrincipal>() ?: error("No principal")
+                call.sessions.set("SESSION", MySession(principal.name))
+                call.respondRedirect("/", permanent = false)
+            }
         }
     }
 } 
@@ -306,7 +308,7 @@ This artifact provides an extension to respond with HTML blocks:
 
 ```kotlin
 get("/") { 
-    val data = IndexData(listOf(1, 2, 3)))  
+    val data = IndexData(listOf(1, 2, 3))
     call.respondHtml {
         head {
             link(rel = "stylesheet", href = "/static/styles.css")


### PR DESCRIPTION
1. The path is changed to the correct path, that used on the screenshot
2. Changed the margins
3. Added `routing {}` and missed argument for `call.sessions.set`
4. Delete odd round bracket