### PR TITLE
Update multipart/form-data example to use MultiPartFormDataContent

### DIFF
--- a/clients/http-client/calls/requests.md
+++ b/clients/http-client/calls/requests.md
@@ -267,7 +267,7 @@ Alternatively you can set the body directly:
 ```kotlin
 val request = client.request {
     method = HttpMethod.Post
-    body = FormDataContent(formData {
+    body = MultiPartFormDataContent(formData {
         append("key", "value")
     })
 }


### PR DESCRIPTION
`MultiPartFormDataContent` should be used with the `formData { ... }` DSL used in the example.