### PR TITLE
Fix sample code in OAuth server documentation

### DIFF
--- a/servers/features/authentication/oauth.md
+++ b/servers/features/authentication/oauth.md
@@ -33,7 +33,7 @@ val loginProviders = listOf(
             clientId = "***",
             clientSecret = "***"
     )
-)
+).associateBy {it.name}
 
 install(Authentication) {
     oauth("gitHubOAuth") {


### PR DESCRIPTION
The following line raises an error because the "type" properties is a string but loginProviders is a list:
```kotlin
providerLookup = { loginProviders[application.locations.resolve<LoginLocation>(LoginLocation::class, this).type] }
```

Is it possible that this example doesn't work? I added `.associateBy {it.name}` to the loginProviders and now it works for me.
