### PR TITLE
Correcting a misspelling in 0intro.md

### DIFF
--- a/servers/0intro.md
+++ b/servers/0intro.md
@@ -143,7 +143,7 @@ Notice that routes are organized into a tree so you can declare routes structure
 
 ```kotlin
 routing {
-    rouite("profile/{id}") {
+    route("profile/{id}") {
         get("view") { TODO("...") }
         get("settings") { TODO("...") }
     }


### PR DESCRIPTION
The methode route{} was misspelled in 0intro.md