### PR TITLE
Update library path for `ktor-client-websockets`

### DIFF
--- a/clients/2websockets.md
+++ b/clients/2websockets.md
@@ -4,7 +4,7 @@ category: clients
 permalink: /clients/websockets.html
 caption: WebSockets
 feature:
-    artifact: io.ktor:ktor-client-websocket:$ktor_version,io.ktor:ktor-client-cio:$ktor_version,io.ktor:ktor-client-js:$ktor_version,io.ktor:ktor-client-okhttp:$ktor_version
+    artifact: io.ktor:ktor-client-websockets:$ktor_version,io.ktor:ktor-client-cio:$ktor_version,io.ktor:ktor-client-js:$ktor_version,io.ktor:ktor-client-okhttp:$ktor_version
     class: io.ktor.client.features.websocket.WebSockets
 ktor_version_review: 1.2.0
 ---


### PR DESCRIPTION
Seems that older versions of ktor's websocket (like 1.1.4) has the name
`ktor-client-websocket`
and newer versions (like 1.2.x) use the name
`ktor-client-websockets`

