### PR TITLE
Update websockets.md

### DIFF
--- a/clients/http-client/features/websockets.md
+++ b/clients/http-client/features/websockets.md
@@ -3,7 +3,7 @@ title: WebSockets
 category: clients
 caption: WebSockets
 feature:
-  artifact: io.ktor:ktor-client-websocket:$ktor_version
+  artifact: io.ktor:ktor-client-websockets:$ktor_version
   class: io.ktor.client.features.websocket.ClientWebSocketSession
   method: io.ktor.client.features.websocket.ws
 ktor_version_review: 1.2.0


### PR DESCRIPTION
Seems that older versions of ktor's websocket (like 1.1.4) has the name
`ktor-client-websocket`
and newer versions (like 1.2.x) use the name
`ktor-client-websockets`