### PR TITLE
Explicitly mention how to use multiplatform Ktor on JVM

### DIFF
--- a/clients/http-client/2multiplatform.md
+++ b/clients/http-client/2multiplatform.md
@@ -25,6 +25,10 @@ dependencies {
 }
 ```
 
+## JVM
+
+To use Ktor on JVM, you have to include [one of the supported JVM Engines](https://ktor.io/clients/http-client/engines.html#jvm) to your  `build.gradle`(`build.gradle.kts`).
+
 ## Android
 
 To use Android engine you have to add the dependency in your `build.gradle`(`build.gradle.kts`):


### PR DESCRIPTION
At the moment, multiplatform page might be a bit confusing since all platforms are explicitly explained, except for JVM (which has its own page).

This adds explicit mention and redirect to the JVM engine list.