### PR TITLE
Change parameter TheApp to this

### DIFF
--- a/servers/features/templates/freemarker.md
+++ b/servers/features/templates/freemarker.md
@@ -18,7 +18,7 @@ feature.  Initialize the FreeMarker feature with a
 
 ```kotlin
     install(FreeMarker) {
-        templateLoader = ClassTemplateLoader(TheApp::class.java.classLoader, "templates")
+        templateLoader = ClassTemplateLoader(this::class.java.classLoader, "templates")
     }
 ```
 


### PR DESCRIPTION
This fixes an unresolved reference error in 
`templateLoader = ClassTemplateLoader(TheApp::class.java.classLoader, "templates")`
TheApp is unknown and changing it to this fixes the error and FreeMarker feature is successfully installed.