### PR TITLE
Update reference of Metrics feature example to DropwizardMetrics.kt

### DIFF
--- a/advanced/pipeline/route.md
+++ b/advanced/pipeline/route.md
@@ -87,5 +87,5 @@ pipeline.environment.monitor.subscribe(Routing.RoutingCallFinished) { call: Rout
 }
 ```
 
-You can see a full example of this in the [Metrics feature](https://github.com/ktorio/ktor/blob/master/ktor-features/ktor-metrics/src/io/ktor/metrics/Metrics.kt).
+You can see a full example of this in the [Metrics feature](https://github.com/ktorio/ktor/blob/master/ktor-features/ktor-metrics/jvm/src/io/ktor/metrics/dropwizard/DropwizardMetrics.kt).
 


### PR DESCRIPTION
The link 'Metrics feature' at the bottom of
https://ktor.io/advanced/pipeline/route.html#hooking-before-and-after-routing
targets to the moved file `https://github.com/ktorio/ktor/blob/master/ktor-features/ktor-metrics/src/io/ktor/metrics/Metrics.kt`
Changed it to the new localtion and name `https://github.com/ktorio/ktor/blob/master/ktor-features/ktor-metrics/jvm/src/io/ktor/metrics/dropwizard/DropwizardMetrics.kt`