### PR TITLE
Updating shadow plugin version

### DIFF
--- a/quickstart/quickstart/docker.md
+++ b/quickstart/quickstart/docker.md
@@ -39,7 +39,7 @@ buildscript {
     }
     dependencies {
         ...
-        classpath "com.github.jengelman.gradle.plugins:shadow:2.0.1"
+        classpath "com.github.jengelman.gradle.plugins:shadow:5.1.0"
     }
 }
 ```


### PR DESCRIPTION
Could not build with version 2.0.1 using the provided instructions. Projects appear to build fine with version 5.1.0.