### PR TITLE
Fix typo

### DIFF
--- a/servers/features/sessions/transformers.md
+++ b/servers/features/sessions/transformers.md
@@ -80,7 +80,7 @@ It is important to note that changing the key will invalidate all the sessions f
 ### SessionTransportTransformerMessageAuthentication
 {: #SessionTransportTransformerMessageAuthentication}
 
-The `SessionTransportTransformerEncrypt` provides a session transport transformer that includes
+The `SessionTransportTransformerMessageAuthentication` provides a session transport transformer that includes
 an authenticated hash of the payload and verifies it. It is similar to SessionTransportTransformerDigest
 but uses a HMAC. It uses `HmacSHA265` as the default authentication algorithm, but it can be changed.
 It doesn't encrypt the payload, but still without the key people shouldn't be able to change it.


### PR DESCRIPTION
In the section of `SessionTransportTransformerMessageAuthentication`, the first line says `SessionTransportTransformerEncrypt`.
(its contents is correctly for `SessionTransportTransformerMessageAuthentication`, and `SessionTransportTransformerEncrypt` is described in the next section.)