### PR TITLE
Include information about K/JS usage for ktor-client-json

### DIFF
--- a/clients/http-client/features/json-feature.md
+++ b/clients/http-client/features/json-feature.md
@@ -21,6 +21,10 @@ You have a [full example using JSON](/clients/http-client/examples.html#example-
 
 {% include feature.html %}
 
+To use this feature with Kotlin/JS, you need to include the `io.ktor:ktor-client-json-js` artifact.
+{: .note.artifact }
+
+
 ## Serializers
 
 The `JsonFeature` has a default serializer(implicitly obtained or by calling `defaultSerializer()`)


### PR DESCRIPTION
Adds previously missing info about using `ktor-client-json-js` to the docs.