### PR TITLE
Fix Maven tab in Artifact screen to correctly list all dependencies

### DIFF
--- a/_includes/artifact.html
+++ b/_includes/artifact.html
@@ -85,7 +85,7 @@
     ...
     &lt;dependencies&gt;
 {%- for artifact in artifacts -%}
-    {%- assign artifact_parts = include.artifact | split: ':' -%}
+    {%- assign artifact_parts = artifact | split: ':' -%}
     {%- assign artifact_group = artifact_parts[0] -%}
     {%- assign artifact_name = artifact_parts[1] -%}
     {%- assign artifact_version = artifact_parts[2] %}


### PR DESCRIPTION
I've noticed that [this page](https://ktor.io/clients/websockets.html) in the documentation correctly lists all Gradle dependencies, but Maven dependencies tab is wrong, because the first dependency is repeated there.

This should fix it.