### PR TITLE
Fix display of test artifacts in Gradle Kotlin DSL

### DIFF
--- a/_includes/artifact.html
+++ b/_includes/artifact.html
@@ -69,7 +69,8 @@
         <div id="artifact-gradle-kotlin-{{ autoid }}" class="tab-pane fade in">
             {% if include.test %}
             <div><code style="white-space: pre;font-size: 0.9em">dependencies {
-    testCompile("{{ include.artifact }}")
+{% for artifact in artifacts %}    testImplementation("{{ artifact }}")
+{% endfor -%}
 }
 </code></div>
             {% else %}


### PR DESCRIPTION
List artifacts individually and use 'testImplementation' ('testCompile' is deprecated).

Current issue:
![Screenshot from 2019-11-29 12-23-44](https://user-images.githubusercontent.com/115275/69866003-251f5100-12a3-11ea-8dab-eaa825103dea.png)