### PR TITLE
Fix performance issue in autoreload.md

### DIFF
--- a/servers/autoreload.md
+++ b/servers/autoreload.md
@@ -156,7 +156,7 @@ Since the Autoreload feature only detects changes in class files, you have to co
 You can do it using IntelliJ IDEA with `Build -> Build Project` while running.
 
 However, you can also use gradle to automatically detect source changes and compile it for you. You can just open
-another terminal in your project folder and run: `gradle -t build`.
+another terminal in your project folder and run: `gradle -t installDist`.
 
 It will compile the application, and after doing so,
 it will listen for additional source changes and recompile when necessary. And thus, triggering Automatic class reloading.


### PR DESCRIPTION
Using `gradle -t build` tests (and lints) the program, which is unnecessary during development. It is unnecessary to run tests during the first run when automatic reload is enabled, since the program will continuously be fluctuating in terms of tests passing while being worked on. Linting is pointless for obvious reasons in this stage.

I was initially using the `assemble` task in place of `build` precisely for these same reasons, but the performance hit while using a bind mount in a Docker container was still far too severe. After some digging, I found that `assemble` compresses distributions (which takes roughly half the task's time), as well as runs the shadow tasks if the Shadow JAR plugin is present (which takes roughly half the task's time).

Since it took me quite a long time to fix this, I think it is worth updating the official documentation so that beginners won't waste time on this.