### PR TITLE
Remove artifacts information because they are redundant

### DIFF
--- a/clients/http-client/features/json-feature.md
+++ b/clients/http-client/features/json-feature.md
@@ -26,9 +26,6 @@ You have a [full example using JSON](/clients/http-client/examples.html#example-
     classifiers=",-jvm,-native,-js"
 %}
 
-To use this feature with Kotlin/JS, you need to include the `io.ktor:ktor-client-json-js` artifact.
-{: .note.artifact }
-
 
 ## Serializers
 
@@ -79,9 +76,6 @@ val client = HttpClient(HttpClientEngine) {
     }
 }
 ```
-
-To use this feature, you need to include `io.ktor:ktor-client-serialization-jvm` artifact on the JVM and `io.ktor:ktor-client-serialization-native` on iOS.
-{: .note.artifact }
 
 {% include 
     mpp_feature.html


### PR DESCRIPTION
I've removed these artifacts information boxes because they were redundant with the tabbed-box:
![Screenshot 2019-12-18 at 10 48 06](https://user-images.githubusercontent.com/10229883/71075216-fac70200-2183-11ea-9378-922af495fee8.png)
![Screenshot 2019-12-18 at 10 48 10](https://user-images.githubusercontent.com/10229883/71075218-fac70200-2183-11ea-857c-6172e530d4c7.png)
