### PR TITLE
Small typo: Correct class name for MicrometerMetrics

### DIFF
--- a/servers/features/metrics-micrometer.md
+++ b/servers/features/metrics-micrometer.md
@@ -5,7 +5,7 @@ category: servers
 permalink: /servers/features/metrics-micrometer.html
 feature:
   artifact: io.ktor:ktor-metrics-micrometer:$ktor_version
-  class: io.ktor.metrics.MicrometerMetrics
+  class: io.ktor.metrics.micrometer.MicrometerMetrics
 redirect_from:
 - /features/metrics.html
 ktor_version_review: 1.0.0


### PR DESCRIPTION
The class MicrometerMetrics is in the package io.ktor.metrics.micrometer (see [https://github.com/ktorio/ktor/blob/master/ktor-features/ktor-metrics-micrometer/jvm/src/io/ktor/metrics/micrometer/MicrometerMetrics.kt](the source code)), so the class name at the top of this page is incorrect.