### PR TITLE
improve and align template samples

### DIFF
--- a/servers/features/templates/freemarker.md
+++ b/servers/features/templates/freemarker.md
@@ -39,8 +39,10 @@ With that template in `resources/templates` it is accessible elsewhere in the th
 using the `call.respond()` method:
 
 ```kotlin
-    get("/{...}") {
-        val user = User("user name", "user@example.com")
-        call.respond(FreeMarkerContent("index.ftl", mapOf("user" to user), "e"))
-    }
+data class User(val name: String, val email: String)
+
+get("/") {
+	val user = User("user name", "user@example.com")
+	call.respond(FreeMarkerContent("hello.ftl", mapOf("user" to user)))
+}
 ```

--- a/servers/features/templates/mustache.md
+++ b/servers/features/templates/mustache.md
@@ -27,20 +27,24 @@ This MustacheFactory sets up Mustache to look for the template files on the clas
 
 {% include feature.html %}
 
+{% raw %}
 ```html
 <html>
-
 <h1>Hello {{ user.name }}</h1>
 
+Your email address is {{ user.email }}
 </html>
 ```
+{% endraw %}
 
 With that template in `resources/templates` it is accessible elsewhere in the the application
 using the `call.respond()` method:
 
 ```kotlin
-    get("/{...}") {
-        val user = User("user name", "user@example.com")
-        call.respond(MustacheContent("todos.hbs", mapOf("user" to user)))
-    }
+data class User(val name: String, val email: String)
+
+get("/") {
+    val user = User("user name", "user@example.com")
+    call.respond(MustacheContent("hello.hbs", mapOf("user" to user)))
+}
 ```

--- a/servers/features/templates/pebble.md
+++ b/servers/features/templates/pebble.md
@@ -38,20 +38,24 @@ This loader will look for the template files on the classpath in the "templates"
 
 A basic template looks like this:
 
+{% raw %}
 ```html
 <html>
+<h2>Hello, {{ user.name }}!</h2>
 
-<p>Hello, {{ user }}</p>
-<h1>{{ title }}</h1>
-
+Your email address is {{ user.email }}
 </html>
 ```
+{% endraw %}
 
 With that template in `resources/templates` it is accessible elsewhere in the the application
 using the `call.respond()` method:
 
 ```kotlin
-    get("/{...}") {
-        call.respond(PebbleContent("hello.html", mapOf("user" to "Anonymous", "title" to "This is Pebble calling!")))
-    }
+data class User(val name: String, val email: String)
+
+get("/") {
+    val user = User("user name", "user@example.com")
+	 call.respond(PebbleContent("hello.html", mapOf("user" to user)))
+}
 ```

--- a/servers/features/templates/thymeleaf.md
+++ b/servers/features/templates/thymeleaf.md
@@ -17,13 +17,13 @@ feature.  Initialize the Thymeleaf feature with a
 [ClassLoaderTemplateResolver](https://www.thymeleaf.org/apidocs/thymeleaf/3.0.1.RELEASE/org/thymeleaf/templateresolver/ClassLoaderTemplateResolver.html):
 
 ```kotlin
-    install(Thymeleaf) {
-        setTemplateResolver(ClassLoaderTemplateResolver().apply { 
-            prefix = "templates/"
-            suffix = ".html"
-            characterEncoding = "utf-8"
-        })
-    }
+install(Thymeleaf) {
+    setTemplateResolver(ClassLoaderTemplateResolver().apply { 
+        prefix = "templates/"
+        suffix = ".html"
+        characterEncoding = "utf-8"
+    })
+}
 ```
 
 This TemplateResolver sets up Thymeleaf to look for the template files on the classpath in the
@@ -34,12 +34,9 @@ This TemplateResolver sets up Thymeleaf to look for the template files on the cl
 ```html
 <!DOCTYPE html >
 <html xmlns:th="http://www.thymeleaf.org">
-<head>
-  <meta charset="UTF-8">
-  <title>Title</title>
-</head>
 <body>
-<span th:text="${user.name}"></span>
+<h2 th:text="'Hello ' + ${user.name} + '!'"></h2>
+<p>Your email address is <span th:text="${user.email}"></span></p>
 </body>
 </html>
 ```
@@ -48,7 +45,10 @@ With that template in `resources/templates` it is accessible elsewhere in the th
 using the `call.respond()` method:
 
 ```kotlin
-    get("/") {
-        call.respond(ThymeleafContent("index", mapOf("user" to User(1, "user1"))))
+data class User(val name: String, val email: String)
+
+get("/") {
+    val user = User("user name", "user@example.com")
+    call.respond(ThymeleafContent("hello", mapOf("user" to user)))
     }
 ```

--- a/servers/features/templates/velocity.md
+++ b/servers/features/templates/velocity.md
@@ -24,14 +24,9 @@ feature.  Initialize the Velocity feature with the
 You can install Velocity, and configure the `VelocityEngine`.
 
 ```kotlin
-install(Velocity) { // this: VelocityEngine
-    setProperty("resource.loader", "string");
-    addProperty("string.resource.loader.class", StringResourceLoader::class.java.name)
-    addProperty("string.resource.loader.repository.static", "false")
-    init() // need to call `init` before trying to retrieve string repository
-    
-    (getApplicationAttribute(StringResourceLoader.REPOSITORY_NAME_DEFAULT) as StringResourceRepository).apply {
-        putStringResource("test.vl", "<p>Hello, \$id</p><h1>\$title</h1>")
+install(Velocity) {
+    setProperty("resource.loader", "classpath")
+    setProperty("classpath.resource.loader.class", ClasspathResourceLoader::class.java.name)
     }
 }
 ```
@@ -42,11 +37,10 @@ install(Velocity) { // this: VelocityEngine
 When Velocity is configured, you can call the `call.respond` method with a `VelocityContent` instance: 
 
 ```kotlin
-routing {
-    val model = mapOf("id" to 1, "title" to "Hello, World!")
+data class User(val name: String, val email: String)
 
-    get("/") {
-        call.respond(VelocityContent("test.vl", model, "e"))
-    }
+get("/") {
+	 val user = User("user name", "user@example.com")
+    call.respond(VelocityContent("templates/hello.vl", user))
 }
 ```


### PR DESCRIPTION
first i saw that the mustache and pebble example didn't render the double curly braces `{{`, so this required a `{% raw %}` and `{% endraw %}` encapsulation (i hope).

i also made the samples more self-contained by adding the `User` data class definition.

also aligned all the template samples (except the html-dsl as it is somehow completely different than the rest), using same filename, render same output...