### PR TITLE
Fixed JWT documentation exemple code

### DIFF
--- a/servers/features/authentication/jwt.md
+++ b/servers/features/authentication/jwt.md
@@ -56,12 +56,19 @@ val jwtRealm = environment.config.property("jwt.realm").getString()
 install(Authentication) {
     jwt {
         realm = jwtRealm
-        verifier(makeJwtVerifier(jwtIssuer), jwtIssuer)
+        verifier(makeJwtVerifier(jwtIssuer, jwtIssuer))
         validate { credential ->
             if (credential.payload.audience.contains(jwtAudience)) JWTPrincipal(credential.payload) else null
         }
     }
 }
+
+private val algorithm = Algorithm.HMAC256("secret")
+private fun makeJwtVerifier(issuer: String, audience: String): JWTVerifier = JWT
+        .require(algorithm)
+        .withAudience(audience)
+        .withIssuer(issuer)
+        .build()
 ```
 
 ## Using a JWK provider:


### PR DESCRIPTION
The example code in the JWT documentation had an error and was missing a crucial function. I fixed the error added the function present in [the sample](https://github.com/ktorio/ktor-samples/blob/master/feature/auth/src/io/ktor/samples/auth/JwtApplication.kt)