### PR TITLE
Improve Grammar in Client Quickstart Section

### DIFF
--- a/clients/http-client/0quick-start.md
+++ b/clients/http-client/0quick-start.md
@@ -7,5 +7,5 @@ children: /clients/http-client/quick-start/
 ktor_version_review: 1.2.0
 ---
 
-Following this guide you'll learn how to setup ktor HTTP client and make your first request:
+By following this guide you'll learn how to setup the Ktor HTTP client and make your first request:
 {% include children_list.html context=page.children %}

--- a/clients/http-client/1engines.md
+++ b/clients/http-client/1engines.md
@@ -26,15 +26,15 @@ val client = HttpClient()
 In the case of the JVM, the default engine is resolved with a ServiceLoader, getting the first one available sorted in alphabetical order.
 Thus depends on the artifacts you have included.
 
-For native, the engine detected during static linkage. Please provide one of the native engines in artifacts.
+For native, the engine is detected during static linkage. Please provide one of the native engines in the artifacts.
 
-For js, it uses the predefined one.
+For JS, it uses the predefined one.
 
 ## Configuring engines
 
 {: #configuring}
 
-Ktor HttpClient lets you configure the parameters of each engine by calling:
+The Ktor HttpClient lets you configure the parameters of each engine by calling:
 
 ```kotlin
 HttpClient(MyHttpEngine) {
@@ -47,7 +47,7 @@ HttpClient(MyHttpEngine) {
 Every engine config has some common properties that can be set:
 
 * The `threadsCount` property is a recommendation to use by an engine. It can be ignored if an engine doesn't require such amount of threads.
-* The `pipelining` is experimental flag to enable [HTTP pipelining](https://en.wikipedia.org/wiki/HTTP_pipelining).
+* The `pipelining` is an experimental flag to enable [HTTP pipelining](https://en.wikipedia.org/wiki/HTTP_pipelining).
 
 ```kotlin
 val client = HttpClient(MyHttpEngine) {
@@ -64,7 +64,9 @@ val client = HttpClient(MyHttpEngine) {
 
 {: #apache}
 
-Apache is the most configurable HTTP client about right now. It supports HTTP/1.1 and HTTP/2. It is the only one that supports following redirects and allows you to configure timeouts, proxies among other things it is supported by `org.apache.httpcomponents:httpasyncclient`.
+Apache is the most configurable HTTP client around right now. It supports HTTP/1.1 and HTTP/2. 
+It is the only one that supports following redirects, and allows you to configure timeouts and proxies. 
+Among other things it is supported by `org.apache.httpcomponents:httpasyncclient`.
 
 A sample configuration would look like:
 
@@ -260,8 +262,8 @@ val client = HttpClient(OkHttp) {
 
 {: #android }
 
-The Android engine doesn't have additional dependencies and uses a ThreadPool with a normal HttpURLConnection,
-to perform the requests. And can be configured like this:
+The Android engine doesn't have additional dependencies and uses a ThreadPool with a normal HttpURLConnection
+to perform the requests. It can be configured like this:
 
 ```kotlin
 val client = HttpClient(Android) {
@@ -283,7 +285,7 @@ val client = HttpClient(Android) {
 
 {: #ios }
 
-The iOS engine uses the asynchronous `NSURLSession` internally. And have no additional configuration.
+The iOS engine uses the asynchronous `NSURLSession` internally, and has no additional configuration.
 
 ```kotlin
 val client = HttpClient(Ios) {
@@ -303,7 +305,7 @@ val client = HttpClient(Ios) {
 
 The `Js` engine, uses the [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) API internally(and `node-fetch` for node.js runtime).
 
-Js engine has no custom configuration.
+The JS engine has no additional configuration.
 
 ```kotlin
 val client = HttpClient(Js) {
@@ -324,7 +326,8 @@ There is an engine based on Curl:
 val client = HttpClient(Curl)
 ```
 
-Supported platforms: linux_x64, macos_x64, mingw_x64. Please note that to use the engine you must have the installed curl library at least version 7.63
+Supported platforms: linux_x64, macos_x64, mingw_x64. 
+Please note that to use this engine you must have at least version 7.63 of the [Curl library](https://github.com/curl/curl) installed.
 
 {% include artifact.html kind="engine" class="io.ktor.client.engine.curl.Curl" artifact="io.ktor:ktor-client-curl:$ktor_version" %}
 

--- a/clients/http-client/1engines.md
+++ b/clients/http-client/1engines.md
@@ -6,7 +6,8 @@ caption: HTTP Client Engines
 ktor_version_review: 1.2.0
 ---
 
-Ktor HTTP Client has a common interface but allows to specify an engine that processes the network request. Different engines have different configurations, dependencies and supporting features.
+The Ktor HTTP Client has a common interface, but allows you to specify the engine that processes the network request.
+Different engines have different configurations, dependencies and supporting features.
 
 **Table of contents:**
 
@@ -17,14 +18,14 @@ Ktor HTTP Client has a common interface but allows to specify an engine that pro
 
 {: #default}
 
-By calling to the `HttpClient` method without specifying an engine, it uses a default engine.
+By calling the `HttpClient` method without specifying an engine it uses a default engine, which is platform-specific.
 
 ```kotlin
 val client = HttpClient()
 ```
 
-In the case of the JVM, the default engine is resolved with a ServiceLoader, getting the first one available sorted in alphabetical order.
-Thus depends on the artifacts you have included.
+On the JVM, the default engine is resolved with a ServiceLoader, using the first one by alphabetical order of name.
+So which engine is loaded depends on the artifacts you have included.
 
 For native, the engine is detected during static linkage. Please provide one of the native engines in the artifacts.
 

--- a/clients/http-client/2multiplatform.md
+++ b/clients/http-client/2multiplatform.md
@@ -44,8 +44,8 @@ You can then use Android Studio, or Gradle to build your project.
 
 ## iOS
 
-In the case of iOS, you have to use [Kotlin/Native](https://github.com/JetBrains/kotlin-native), and analogously
-to android, you have to put this artifact as part of the `dependencies` block.
+On iOS, you have to use [Kotlin/Native](https://github.com/JetBrains/kotlin-native), and analogously
+to Android, you have to include this artifact as part of the `dependencies` block.
 
 ```kotlin
 dependencies {
@@ -70,7 +70,7 @@ dependencies {
 
 ## Posix compatible desktops: MacOS, Linux, Windows
 
-As an alternative to JVM compatible engines, you also could use ktor client with [Kotlin/Native](https://github.com/JetBrains/kotlin-native)using `curl` backend.
+As an alternative to JVM-compatible engines, you also could use a Ktor client with the [Kotlin/Native](https://github.com/JetBrains/kotlin-native)using the `curl` backend.
 
 ```kotlin
 dependencies {
@@ -89,7 +89,7 @@ Android and iOS applications directly from Gradle.
 ### Android tasks
 
 * `:client-mpp-android:emulatorList` - lists all the available emulators
-* `:client-mpp-android:emulatorStart` - starts the emulator (this would block Gradle for now, so better to do in a separate terminal)
+* `:client-mpp-android:emulatorStart` - starts the emulator (this blocks Gradle for now, so it's better to do this in a separate terminal)
 * `:client-mpp-android:emulatorInstall` - install the application inside the emulator
 * `:client-mpp-android:emulatorRun` - executes the application inside the emulator
 

--- a/clients/http-client/2multiplatform.md
+++ b/clients/http-client/2multiplatform.md
@@ -16,7 +16,7 @@ Right now, the supported platforms are JVM, Android, iOS, Js and native.
 For [multiplatform projects](https://kotlinlang.org/docs/reference/multiplatform.html) that for example
 share code between multiple platforms, we can create a common module.
 That common module can only access APIs that are available on all the targets.
-Ktor HTTP Client exposes a common module that can be used for such projects:
+The Ktor HTTP Client exposes a common module that can be used for such projects:
 
 ```kotlin
 dependencies {
@@ -27,11 +27,11 @@ dependencies {
 
 ## JVM
 
-To use Ktor on JVM, you have to include [one of the supported JVM Engines](https://ktor.io/clients/http-client/engines.html#jvm) to your  `build.gradle`(`build.gradle.kts`).
+To use Ktor on the JVM, you have to include [one of the supported JVM Engines](https://ktor.io/clients/http-client/engines.html#jvm) to your  `build.gradle`(`build.gradle.kts`).
 
 ## Android
 
-To use Android engine you have to add the dependency in your `build.gradle`(`build.gradle.kts`):
+To use the Android engine you have to add the dependency in your `build.gradle`(`build.gradle.kts`):
 
 ```kotlin
 dependencies {
@@ -54,11 +54,12 @@ dependencies {
 }
 ```
 
-In the case of iOS, we usually create a `.framework`, and the application project is a regular XCode project written either in Swift or Objective-C that includes that framework. So you first have to build the framework using the Gradle tasks exposed by Kotlin/Native, and then open the XCode project.
+In the case of iOS, we usually create a `.framework`, and the application project is a regular XCode project written either in Swift or Objective-C that includes that framework. 
+So you first have to build the framework using the Gradle tasks exposed by Kotlin/Native, and then open the XCode project.
 
 ## Javascript
 
-In the case of a browser or node-js applications, you have to use [Kotlin/Js](https://kotlinlang.org/docs/tutorials/javascript/kotlin-to-javascript/kotlin-to-javascript.html).
+In the case of a browser or node-js application, you have to use [Kotlin/Js](https://kotlinlang.org/docs/tutorials/javascript/kotlin-to-javascript/kotlin-to-javascript.html).
 
 ```kotlin
 dependencies {
@@ -80,7 +81,7 @@ dependencies {
 
 ## Samples
 
-There is a full sample using the common client in the ktor-samples repository [mpp/client-mpp](https://github.com/ktorio/ktor-samples/tree/master/mpp/client-mpp).
+There is a full sample using the common client in the `ktor-samples` repository [mpp/client-mpp](https://github.com/ktorio/ktor-samples/tree/master/mpp/client-mpp).
 
 You can use this project as a reference. This project also expose some experimental Gradle tasks to build, install and run the
 Android and iOS applications directly from Gradle.
@@ -100,6 +101,6 @@ Android and iOS applications directly from Gradle.
 * `:client-mpp-ios:installSimulator` - installs the application inside the simulator
 * `:client-mpp-ios:launchSimulator` - executes the application inside the simulator
 
-Since those tasks are experimental, might fail with your specific setup. Please let us know so we can improve them.
+Since those tasks are experimental, they might fail with your specific setup. Please let us know so we can improve them.
 Or help us with [the iOS tasks](https://github.com/ktorio/ktor-samples/blob/master/mpp/client-mpp/ios/build.gradle){:target="_blank"},
 and [the Android ones](https://github.com/ktorio/ktor-samples/blob/master/mpp/client-mpp/android/build.gradle){:target="_blank"}.

--- a/clients/http-client/quick-start/client.md
+++ b/clients/http-client/quick-start/client.md
@@ -57,7 +57,8 @@ It's safe to create multiple client instances, or use the same client for multip
 
 ## Releasing resources
 
-Ktor client is holding resources: prepared threads, coroutines and connections. After you finish working with the client, you may wish to release it by calling `close`:
+The Ktor client instance holds resources: prepared threads, coroutines and connections.
+After you finish working with it, you should release those resources by calling `close`:
 
 ```kotlin
 client.close()
@@ -105,7 +106,7 @@ val client = HttpClient(CIO) {
 }
 ```
 
-You also can configure engine using the `engine` method in block:
+You can also configure the engine using the `engine` method, like in this block:
 
 ```kotlin
 val client = HttpClient(CIO) {
@@ -115,6 +116,6 @@ val client = HttpClient(CIO) {
 }
 ```
 
-See [Engines](/clients/http-client/engines.html) section for additional details.
+See the [Engines](/clients/http-client/engines.html) section for additional details.
 
 Proceed to [Preparing the request](/clients/http-client/quick-start/requests.html).

--- a/clients/http-client/quick-start/client.md
+++ b/clients/http-client/quick-start/client.md
@@ -10,15 +10,22 @@ ktor_version_review: 1.3.0
 
 ## Adding an engine dependency
 
-The first thing you need to do before using the client is to add a client engine dependency. Client engine is a request executor that performs requests from ktor API. There are many client engines for each platform available out of the box: [`Apache`](/clients/http-client/engines.html#apache),
-[`OkHttp`](/clients/http-client/engines.html#okhttp),
-[`Android`](/clients/http-client/engines.html#android),
-[`Ios`](/clients/http-client/engines.html#ios),
-[`Js`](/clients/http-client/engines.html#js-javascript),
-[`Jetty`](/clients/http-client/engines.html#jetty),
-[`CIO`](/clients/http-client/engines.html#cio) and [`Mock`](/clients/http-client/testing.html). You can read more in the [Multiplatform](/clients/http-client/multiplatform.html) section.
+The first thing you need to do before using the client is to add a client engine dependency. 
+A Client engine is a request executor that performs requests from the Ktor API. 
+There are many client engines for each platform available out of the box: 
 
-For example you can add `CIO` engine dependency in `build.gradle` like this:
+* [`Android`](/clients/http-client/engines.html#android),
+* [`Apache`](/clients/http-client/engines.html#apache),
+* [`CIO`](/clients/http-client/engines.html#cio) and
+* [`Ios`](/clients/http-client/engines.html#ios),
+* [`Jetty`](/clients/http-client/engines.html#jetty),
+* [`Js`](/clients/http-client/engines.html#js-javascript),
+* [`Mock`](/clients/http-client/testing.html). 
+* [`OkHttp`](/clients/http-client/engines.html#okhttp),
+
+You can read more in the [Multiplatform](/clients/http-client/multiplatform.html) section.
+
+For example you can add the `CIO` engine dependency in `build.gradle` like this:
 
 ```kotlin
 dependencies {
@@ -28,13 +35,14 @@ dependencies {
 
 ## Creating client
 
-Next you can create client as here:
+Next you can create a client like so:
 
 ```kotlin
 val client = HttpClient(CIO)
 ```
 
-where `CIO` is engine class here. If you confused which engine class you should use consider using `CIO`.
+where `CIO` is the engine class here. 
+If you are confused about which engine class to use, consider using `CIO`.
 
 If you're using multiplatform, you can omit the engine:
 
@@ -42,9 +50,10 @@ If you're using multiplatform, you can omit the engine:
 val client = HttpClient()
 ```
 
-Ktor will choose an engine among the ones that are available from the included artifacts using a `ServiceLoader` on the JVM, or similar approach in the other platforms. If there are multiple engines in the dependencies Ktor chooses first in alphabetical order of engine name.
+Ktor will choose an engine among the ones that are available from the included artifacts using a `ServiceLoader` on the JVM,
+or a similar approach in the other platforms. If there are multiple engines in the dependencies, Ktor chooses by alphabetical order of engine name.
 
-It's safe to create multiple instance of client or use the same client for multiple requests.
+It's safe to create multiple client instances, or use the same client for multiple requests.
 
 ## Releasing resources
 
@@ -54,7 +63,8 @@ Ktor client is holding resources: prepared threads, coroutines and connections. 
 client.close()
 ```
 
-If you want to use a client to make only one request consider `use`-ing it. The client will be automatically closed once the passed block has been executed:
+If you want to use a client to make only one request consider `use`-ing it.
+The client will be automatically closed once the passed block has been executed:
 
 ```kotlin
 val status = HttpClient().use { client ->
@@ -62,7 +72,9 @@ val status = HttpClient().use { client ->
 }
 ```
 
-The method `close` signals to stop executing new requests. It wouldn't block and allows all current requests to finish successfully and release resources. You can also wait for closing with the `join` method or halt any activity using the `cancel` method. For example:
+The `close` method signals the client to stop executing new requests.
+It won't block, and allows all current requests to finish successfully and release resources.
+You can also wait for the client to close with the `join` method, or halt any activity using the `cancel` method. For example:
 
 ```kotlin
 try {
@@ -77,11 +89,13 @@ try {
 }
 ```
 
-Ktor HttpClient follows `CoroutineScope` lifecycle. Check out [Coroutines guide](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-coroutine-scope/) to learn more.
+The Ktor HttpClient follows the `CoroutineScope` lifecycle. 
+Check out the [Coroutines guide](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-coroutine-scope/) to learn more.
 
 ## Client configuration
 
-To configure the client you can pass additional functional parameter to client constructor. The client configured with [HttpClientEngineConfig](https://api.ktor.io/{{ site.ktor_version }}/io.ktor.client.engine/-http-client-engine-config/index.html).
+To configure the client you can pass additional functional parameters to the client's constructor.
+The client is configured with [HttpClientEngineConfig](https://api.ktor.io/{{ site.ktor_version }}/io.ktor.client.engine/-http-client-engine-config/index.html).
 
 For example you can limit `threadCount` or setup [proxy](/clients/http-client/features/proxy.html):
 

--- a/clients/http-client/quick-start/request.md
+++ b/clients/http-client/quick-start/request.md
@@ -17,13 +17,13 @@ Most of the simple requests are made with pattern
 val response = client.'http-method'<'ResponseType'>("url-string")
 ```
 
-or even simpler form(due to kotlin generic type inference):
+or an even simpler form (due to Kotlin's generic type inference):
 
 ```
 val response: ResponseType = client.'http-method'("url-string")
 ```
 
-For example to perform a `GET` request fully reading a `String`:
+For example to perform a `GET` request to fully read a `String`:
 
 ```kotlin
 val htmlContent = client.get<String>("https://en.wikipedia.org/wiki/Main_Page")
@@ -31,7 +31,7 @@ val htmlContent = client.get<String>("https://en.wikipedia.org/wiki/Main_Page")
 val content: String = client.get("https://en.wikipedia.org/wiki/Main_Page")
 ```
 
-And in the case you are interested in the raw bits, you can read a `ByteArray`:
+And if you are interested in the raw bits, you can read a `ByteArray`:
 
 ```kotlin
 val channel: ByteArray = client.get("https://en.wikipedia.org/wiki/Main_Page")
@@ -54,11 +54,11 @@ data class User(val id: Int)
 val response: User = client.get("https://myapi.com/user?id=1")
 ```
 
-Please note that some of response types are `Closeable` and can hold resources.
+Please note that some response types are `Closeable` and can hold resources.
 
 ## Customizing requests
 
-We cannot live only on *get* requests, Ktor allows you to build complex requests with any of the HTTP verbs, with the flexibility to process responses in many ways.
+We cannot live only on *get* requests. Ktor allows you to build complex requests with any of the HTTP verbs, with the flexibility to process responses in many ways.
 
 ### Default http methods
 
@@ -122,7 +122,7 @@ val call = client.request<String> {
 {: #submit-form }
 
 There are a couple of convenience extension methods for submitting form information.
-The detailed refrence is listed [here](https://api.ktor.io/{{ site.ktor_version }}/io.ktor.client.request.forms/).
+The detailed reference is [here](https://api.ktor.io/{{ site.ktor_version }}/io.ktor.client.request.forms/).
 
 The `submitForm` method:
 
@@ -134,7 +134,8 @@ client.submitForm(
 )
 ```
 
-It allows requesting with the `Parameters` encoded in the query string(`GET` by default) or requesting with the `Parameters` encoded as multipart(`POST` by default) depending on the `encodeInQuery` parameter.
+This allows requesting with the `Parameters` encoded in the query string(`GET` by default),
+or requesting with the `Parameters` encoded as multipart (`POST` by default) depending on the `encodeInQuery` parameter.
 
 The `submitFormWithBinaryData` method:
 
@@ -145,7 +146,7 @@ client.submitFormWithBinaryData(
 ): T
 ```
 
-It allows to generate a multipart POST request from a list of `PartData`.
+This allows you to generate a multipart POST request from a list of `PartData`.
 `PartData` can be `PartData.FormItem`, `PartData.BinaryItem` or `PartData.FileItem`.
 
 To build a list of `PartData`, you can use the `formData` builder:
@@ -191,7 +192,7 @@ headers { // this: HeadersBuilder
 }
 ```
 
-Complete `HeadersBuilder` API is listed [here](https://api.ktor.io/{{ site.ktor_version }}/io.ktor.http/-headers-builder/).
+The complete `HeadersBuilder` API is listed [here](https://api.ktor.io/{{ site.ktor_version }}/io.ktor.http/-headers-builder/).
 
 ## Specifying a body for requests
 

--- a/clients/http-client/quick-start/request.md
+++ b/clients/http-client/quick-start/request.md
@@ -11,7 +11,7 @@ ktor_version_review: 1.3.0
 ## Making request
 
 After client configuration we're ready to perform our first request.
-Most of the simple requests are made with pattern
+Most simple requests are made according to this pattern:
 
 ```
 val response = client.'http-method'<'ResponseType'>("url-string")
@@ -43,9 +43,11 @@ Or get full [HttpResponse](https://api.ktor.io/{{ site.ktor_version }}/io.ktor.c
 val response: HttpResponse = client.get("https://en.wikipedia.org/wiki/Main_Page")
 ```
 
-The [HttpResponse](https://api.ktor.io/{{ site.ktor_version }}/io.ktor.client.statement/-http-response/index.html) is downloaded in memory by default. To learn how to download response partially or work with a stream data consult with the [Streaming](/clients/http-client/quick-start/streaming.html) section.
+The [HttpResponse](https://api.ktor.io/{{ site.ktor_version }}/io.ktor.client.statement/-http-response/index.html) is downloaded into memory by default. 
+To learn how to download a response partially or work with stream data,
+consult the [Streaming](/clients/http-client/quick-start/streaming.html) section.
 
-And even your data class using [Json](/clients/http-client/features/json-feature.html) feature:
+You can even use your own data class, with the [Json](/clients/http-client/features/json-feature.html) feature:
 
 ```kotlin
 @Serializable
@@ -71,8 +73,10 @@ with the most common HTTP verbs: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`
 val text = client.post<String>("http://127.0.0.1:8080/")
 ```
 
-When calling request methods, you can provide a lambda to build the request
-parameters like the URL, the HTTP method(verb), the body, or the headers:
+When calling request methods you can provide a lambda to build the request parameters — such as the URL,
+the HTTP method (verb), the body, or the headers:
+
+<!-- TODO: more comprehensive example of this? -->
 
 ```kotlin
 val text = client.post<String>("http://127.0.0.1:8080/") {
@@ -107,7 +111,7 @@ You can check the standard available [HttpClient build extension methods](https:
 ### Customize method
 
 In addition to call, there is a `request` method for performing a typed request,
-[receiving a specific type](/clients/http-client/quick-start/responses.html#receive) like String, HttpResponse, or an arbitrary class.
+[receiving a specific type](/clients/http-client/quick-start/responses.html#receive) like `String`, `HttpResponse`, or an arbitrary class.
 You have to specify the URL and the method when building the request.
 
 ```kotlin
@@ -169,7 +173,7 @@ val data: List<PartData> = formData {
 
 When building requests with `HttpRequestBuilder`, you can set custom headers.
 There is a final property `val headers: HeadersBuilder` that inherits from `StringValuesBuilder`.
-You can add or remove headers using it, or with the `header` convenience methods.
+You can add or remove headers using this, or with the `header` convenience methods.
 
 ```kotlin
 // this : HttpMessageBuilder

--- a/clients/http-client/quick-start/response.md
+++ b/clients/http-client/quick-start/response.md
@@ -31,7 +31,7 @@ val helloWorld = client.get<HelloWorld>("http://127.0.0.1:8080/")
 
 {: #HttpResponse }
 
-`HttpResponse` API reference is listed [here](https://api.ktor.io/{{site.ktor_version}}/io.ktor.client.response/-http-response/).
+The `HttpResponse` API reference is listed [here](https://api.ktor.io/{{site.ktor_version}}/io.ktor.client.response/-http-response/).
 
 From an `HttpResponse`, you can get the response content easily:
 


### PR DESCRIPTION
I've reworded things slightly in places, fixed some minor second-language-English errors and unnatural sounding phrasings.

Although it was understandable before, this improves the documentation's readability for me, which lowers the barrier to entry for learning and using this library.
