### PR TITLE
Update serialization-converter.md

### DIFF
--- a/servers/features/content-negotiation/serialization-converter.md
+++ b/servers/features/content-negotiation/serialization-converter.md
@@ -37,13 +37,13 @@ The `serialization()` function has two optional parameters with default argument
 Advanced example:
 ```kotlin
 install(ContentNegotiation) {
-    serialization(
-        contentType = ContentType.Application.Json,
+    json(
         json = Json(
-            DefaultJsonConfiguration.copy(
+            JsonConfiguration.Stable.copy(
                 prettyPrint = true
             )
-        )
+        ),
+        contentType = ContentType.Application.Json
     )
 }
 ```


### PR DESCRIPTION
Update advanced configuration example. The `serialization(...)` version in the docs is now deprecated.