### PR TITLE
Fix argument in makeJwtVerifier()

### DIFF
--- a/servers/features/authentication/jwt.md
+++ b/servers/features/authentication/jwt.md
@@ -56,7 +56,7 @@ val jwtRealm = environment.config.property("jwt.realm").getString()
 install(Authentication) {
     jwt {
         realm = jwtRealm
-        verifier(makeJwtVerifier(jwtIssuer, jwtIssuer))
+        verifier(makeJwtVerifier(jwtIssuer, jwtAudience))
         validate { credential ->
             if (credential.payload.audience.contains(jwtAudience)) JWTPrincipal(credential.payload) else null
         }


### PR DESCRIPTION
There is a mistake in [JWT guide](https://ktor.io/servers/features/authentication/jwt.html). In `verifier(makeJwtVerifier(jwtIssuer, jwtIssuer))` parameter `jwtIssuer` is repeated 2 times. 
My pull request corrects to `verifier(makeJwtVerifier(jwtIssuer, jwtAudience))`. Otherwise aud is not required at all in the example:
![code](https://i.paste.pics/3177747756ba710e97da4df8a47820b9.png)
If this is not corrected, then when trying to authorize, it will give an error:
 `io.ktor.auth.jwt - Token verification failed: The Claim 'aud' value doesn't contain the required audience.`

I met this error on:
>Ktor 1.3.2
>Kotlin JVM 1.3.72
