### PR TITLE
Use https for the jcenter repository in final pom

### DIFF
--- a/quickstart/quickstart/maven.md
+++ b/quickstart/quickstart/maven.md
@@ -255,7 +255,7 @@ When you are done, the `pom.xml` file should look like:
     <repositories>
         <repository>
             <id>jcenter</id>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
         </repository>
     </repositories>
 </project>


### PR DESCRIPTION
The reference to the jcenter repository has https earlier in the page, but in the "final pom" section it's still http.