### PR TITLE
Move GitHub Issues to YouTrack Issues

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -69,7 +69,7 @@ layout: default
             <div class="note contact" style="margin-top: 32px; max-width:860px; margin-left: auto; margin-right: auto;">
                 Want to provide feedback, report bugs or ask questions?<br />
                 Head over our #ktor <a href="http://slack.kotlinlang.org/" target="_blank" rel="noopener">Kotlin Slack</a> channel, and we will try to help you!<br/>
-                You can also contribute by creating issues or pull requests in our <a href="https://github.com/ktorio/ktor">public GitHub repository</a>.
+                You can also contribute by creating issues or pull requests in our <a href="https://youtrack.jetbrains.com/newIssue?project=KTOR">YouTrack Project</a>.
             </div>
         </div>
     </div>


### PR DESCRIPTION
You should directly link to YouTrack issues, instead linking to GitHub.