### PR TITLE
Generation of self-signed certificates requires `io.ktor:ktor-network-tls-certificates`

### DIFF
--- a/servers/self-signed-certificate.md
+++ b/servers/self-signed-certificate.md
@@ -8,7 +8,7 @@ permalink: /servers/self-signed-certificate.html
 
 Ktor allows you to create and use self-signed certificates for serving HTTPS or HTTP/2 requests.
 
-{% include artifact.html kind="function" method="io.ktor.network.tls.certificates.generateCertificate" artifact="io.ktor:ktor-network-tls:$ktor_version" %}
+{% include artifact.html kind="function" method="io.ktor.network.tls.certificates.generateCertificate" artifact="io.ktor:ktor-network-tls-certificates:$ktor_version" %}
 
 **Table of contents:**
 


### PR DESCRIPTION
## What

Affected page: https://ktor.io/servers/self-signed-certificate.html

The `Using a Self-Signed Certificate` guide references an incorrect dependency - the `generateCertificate` function mentioned appears to have been moved to `io.ktor:ktor-network-tls-certificates`, from `io.ktor:ktor-network-tls`.

The rest of the guide seems OK for me locally.